### PR TITLE
Fix 'Task' annotation 'name' default value

### DIFF
--- a/src/Annotation/Mapping/Task.php
+++ b/src/Annotation/Mapping/Task.php
@@ -27,7 +27,7 @@ class Task
      *
      * @Required()
      */
-    private $name;
+    private $name = '';
 
     /**
      * Task constructor.

--- a/src/Router/RouteRegister.php
+++ b/src/Router/RouteRegister.php
@@ -57,7 +57,7 @@ class RouteRegister
     public static function registerRoutes(Router $router): void
     {
         foreach (self::$tasks as $className => $task) {
-            $name    = $task['name'] ?? '';
+            $name    = $task['name'] ? $task['name'] : $className;
             $mapping = $task['mapping'] ?? [];
 
             if (empty($name) || empty($mapping)) {


### PR DESCRIPTION
Fix '\Swoft\Task\Annotation\Mapping\Task' annotation 'name' field does not fill out, start error reporting